### PR TITLE
Fix system role deletion scope

### DIFF
--- a/src/backend/apps/meta/tasks.py
+++ b/src/backend/apps/meta/tasks.py
@@ -168,7 +168,7 @@ def sync_iam_system_roles(iam_systems):
             )
 
         if to_delete:
-            SystemRole.objects.filter(username__in=to_delete).delete()
+            SystemRole.objects.filter(system_id=system_id, username__in=to_delete).delete()
     logger.info("[sync_iam_system_roles] finished")
 
 


### PR DESCRIPTION
## Summary
- restrict system role cleanup to current system when syncing IAM system roles

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684131467980832f95bad633f1539dd2